### PR TITLE
Improve bitmask in `_unbind` using solidity

### DIFF
--- a/src/DssSoul.sol
+++ b/src/DssSoul.sol
@@ -195,7 +195,7 @@ contract DssSoul is ERC721, ERC721Enumerable, ERC721Metadata {
         // shift _nft by 96 bits and convert to address
         _soul = address(uint160(_nft >> 96));
         // mask lower 96 bits
-        _kin  = _nft & (2**96 - 1);
+        _kin  = _nft & type(uint96).max;
     }
 
     function _mint(address _to, uint256 _nft, string calldata _uri) private {

--- a/src/DssSoul.sol
+++ b/src/DssSoul.sol
@@ -192,10 +192,10 @@ contract DssSoul is ERC721, ERC721Enumerable, ERC721Metadata {
     }
 
     function _unbind(uint256 _nft) private pure returns (address _soul, uint256 _kin) {
-        assembly {
-            _soul := shr(96, and(_nft, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000))
-            _kin := and(_nft, 0x0000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF)
-        }
+        // shift _nft by 96 bits and convert to address
+        _soul = address(uint160(_nft >> 96));
+        // mask lower 96 bits
+        _kin  = _nft & (2**96 - 1);
     }
 
     function _mint(address _to, uint256 _nft, string calldata _uri) private {


### PR DESCRIPTION
## Rationale

The original code used a combination of assembly code and bitwise operations to extract the `soul` address and `kin` values from a given `nft`. 

However, this can be achieved more clearly and concisely using only Solidity.

To extract the redeemer address, we can shift the `nft` to the right by 96 bits and convert the resulting integer to an address using the `address(uint160)` typecast. This will discard the lower 96 bits of the `nft` and leave only the upper 160 bits, which encode the `soul` address.

To extract the `kin` value, we can use the `&` operator to mask the lower 96 bits of the `nft`. This will leave only the lower 96 bits, which encode the `nft`.

The modified code combines these two operations to extract the `soul` address and `kin` values from a given `nft`:

```solidity
    function _unbind(uint256 _nft) private pure returns (address _soul, uint256 _kin) {
        // shift _nft by 96 bits and convert to address
        _soul = address(uint160(_nft >> 96));
        // mask lower 96 bits
        _kin  = _nft & type(uint96).max;
    }
```

This code is simpler and more readable than the original code, and achieves the same result. It avoids the use of assembly code, making it easier to understand and maintain.